### PR TITLE
Add time offset sync for video/lyrics synchronization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,7 +180,7 @@ function App() {
       // Handle debug panel toggle (D key)
       if (e.code === 'KeyD' && e.shiftKey) {
         e.preventDefault()
-        setShowDebugPanel(prev => {
+        setShowDebugPanel((prev: boolean) => {
           const newValue = !prev
           localStorage.setItem('showDebugPanel', JSON.stringify(newValue))
           console.log('Debug panel:', newValue ? 'ON' : 'OFF')

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react'
+import type { LyricLine } from '../utils/lrcParser'
+
+interface DebugPanelProps {
+  videoTime: number
+  syncOffset: number
+  currentLyricIndex: number
+  lyricsData: LyricLine[]
+  isWaitingForTyping: boolean
+  playerState: number
+  typedText: string
+  currentLyrics: string
+}
+
+export default function DebugPanel({
+  videoTime,
+  syncOffset,
+  currentLyricIndex,
+  lyricsData,
+  isWaitingForTyping,
+  playerState,
+  typedText,
+  currentLyrics
+}: DebugPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(true)
+  
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60)
+    const secs = (seconds % 60).toFixed(2)
+    return `${mins}:${secs.padStart(5, '0')}`
+  }
+  
+  const getPlayerStateText = (state: number): string => {
+    switch(state) {
+      case -1: return 'UNSTARTED'
+      case 0: return 'ENDED'
+      case 1: return 'PLAYING'
+      case 2: return 'PAUSED'
+      case 3: return 'BUFFERING'
+      case 5: return 'CUED'
+      default: return `UNKNOWN (${state})`
+    }
+  }
+  
+  // Calculate timing details
+  const LYRIC_ADVANCE_BUFFER = 0.3
+  // Positive offset = delay lyrics (they appear later in video)
+  const adjustedTime = videoTime + LYRIC_ADVANCE_BUFFER - syncOffset
+  const currentLyric = lyricsData[currentLyricIndex]
+  const nextLyric = lyricsData[currentLyricIndex + 1]
+  const prevLyric = lyricsData[currentLyricIndex - 1]
+  
+  // Calculate time differences
+  const timeToCurrentLyric = currentLyric ? adjustedTime - currentLyric.time : null
+  const timeToNextLyric = nextLyric ? nextLyric.time - adjustedTime : null
+  const timeToPrevLyric = prevLyric ? adjustedTime - prevLyric.time : null
+  
+  // Find which lyric index we should be at based on adjusted time
+  let expectedIndex = -1
+  for (let i = lyricsData.length - 1; i >= 0; i--) {
+    if (adjustedTime >= lyricsData[i].time) {
+      expectedIndex = i
+      break
+    }
+  }
+  
+  const typingProgress = currentLyrics.length > 0 
+    ? Math.round((typedText.length / currentLyrics.length) * 100) 
+    : 0
+    
+  const isIndexMismatch = expectedIndex !== currentLyricIndex && expectedIndex >= 0
+  
+  return (
+    <div className="fixed top-20 right-4 bg-gray-900 text-white text-xs font-mono rounded-lg shadow-xl z-50 border border-gray-700 max-w-md">
+      <div 
+        className="flex items-center justify-between px-3 py-2 border-b border-gray-700 cursor-pointer hover:bg-gray-800"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <span className="font-bold text-green-400">🔍 SYNC DEBUG</span>
+        <span className="text-gray-400">{isExpanded ? '▼' : '▶'}</span>
+      </div>
+      
+      {isExpanded && (
+        <div className="p-3 space-y-2">
+          {/* Video & Sync Info */}
+          <div className="border-b border-gray-800 pb-2">
+            <div className="text-blue-400 font-bold mb-1">TIMING</div>
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span className="text-gray-400">Video Time:</span>
+                <span className="text-yellow-300">{formatTime(videoTime)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-400">Sync Offset:</span>
+                <span className={syncOffset !== 0 ? 'text-orange-400' : 'text-gray-500'}>
+                  {syncOffset > 0 ? '+' : ''}{syncOffset.toFixed(1)}s {syncOffset > 0 ? '(delay)' : syncOffset < 0 ? '(earlier)' : ''}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-400">Advance Buffer:</span>
+                <span className="text-gray-500">+{LYRIC_ADVANCE_BUFFER}s</span>
+              </div>
+              <div className="flex justify-between font-bold">
+                <span className="text-gray-300">Lyric Lookup Time:</span>
+                <span className="text-green-400" title="Time used to find which lyric to show">{formatTime(adjustedTime)}</span>
+              </div>
+            </div>
+          </div>
+          
+          {/* Player State */}
+          <div className="border-b border-gray-800 pb-2">
+            <div className="text-blue-400 font-bold mb-1">PLAYER STATE</div>
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span className="text-gray-400">State:</span>
+                <span className={playerState === 1 ? 'text-green-400' : 'text-yellow-400'}>
+                  {getPlayerStateText(playerState)}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-400">Waiting for Typing:</span>
+                <span className={isWaitingForTyping ? 'text-red-400' : 'text-gray-500'}>
+                  {isWaitingForTyping ? 'YES' : 'NO'}
+                </span>
+              </div>
+            </div>
+          </div>
+          
+          {/* Lyric Indices */}
+          <div className="border-b border-gray-800 pb-2">
+            <div className="text-blue-400 font-bold mb-1">LYRIC TRACKING</div>
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span className="text-gray-400">Current Index:</span>
+                <span className="text-white">{currentLyricIndex}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-400">Expected Index:</span>
+                <span className={isIndexMismatch ? 'text-red-400' : 'text-white'}>
+                  {expectedIndex} {isIndexMismatch && '⚠️'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-400">Total Lyrics:</span>
+                <span className="text-gray-500">{lyricsData.length}</span>
+              </div>
+            </div>
+          </div>
+          
+          {/* Lyric Timing */}
+          <div className="border-b border-gray-800 pb-2">
+            <div className="text-blue-400 font-bold mb-1">LYRIC TIMING</div>
+            <div className="space-y-1">
+              {prevLyric && (
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Prev Lyric [{currentLyricIndex - 1}]:</span>
+                  <span className="text-gray-500">
+                    {formatTime(prevLyric.time)} ({timeToPrevLyric ? `+${timeToPrevLyric.toFixed(1)}s ago` : ''})
+                  </span>
+                </div>
+              )}
+              
+              {currentLyric && (
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Current Lyric [{currentLyricIndex}]:</span>
+                  <span className="text-yellow-300">
+                    {formatTime(currentLyric.time)} 
+                    {timeToCurrentLyric !== null && (
+                      <span className={Math.abs(timeToCurrentLyric) < 0.5 ? 'text-green-400' : 'text-orange-400'}>
+                        {' '}({timeToCurrentLyric > 0 ? '+' : ''}{timeToCurrentLyric.toFixed(1)}s)
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+              
+              {nextLyric && (
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Next Lyric [{currentLyricIndex + 1}]:</span>
+                  <span className="text-cyan-300">
+                    {formatTime(nextLyric.time)} 
+                    {timeToNextLyric !== null && (
+                      <span className={timeToNextLyric < 1 ? 'text-red-400' : 'text-gray-500'}>
+                        {' '}(in {timeToNextLyric.toFixed(1)}s)
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+          
+          {/* Typing Progress */}
+          <div className="border-b border-gray-800 pb-2">
+            <div className="text-blue-400 font-bold mb-1">TYPING PROGRESS</div>
+            <div className="space-y-1">
+              <div className="flex justify-between">
+                <span className="text-gray-400">Typed/Total:</span>
+                <span className={typingProgress === 100 ? 'text-green-400' : 'text-yellow-300'}>
+                  {typedText.length}/{currentLyrics.length} ({typingProgress}%)
+                </span>
+              </div>
+              <div className="w-full bg-gray-700 rounded-full h-2 mt-1">
+                <div 
+                  className={`h-2 rounded-full transition-all ${
+                    typingProgress === 100 ? 'bg-green-400' : 'bg-yellow-400'
+                  }`}
+                  style={{ width: `${typingProgress}%` }}
+                />
+              </div>
+            </div>
+          </div>
+          
+          {/* Current Lyric Text */}
+          <div>
+            <div className="text-blue-400 font-bold mb-1">CURRENT LYRIC</div>
+            <div className="bg-gray-800 p-2 rounded text-gray-300 break-words">
+              {currentLyrics || '(no lyric)'}
+            </div>
+            {currentLyric && currentLyric.text !== currentLyrics && (
+              <div className="mt-1 text-red-400 text-xs">
+                ⚠️ Display mismatch! Expected: "{currentLyric.text}"
+              </div>
+            )}
+          </div>
+          
+          {/* Upcoming Lyrics Preview */}
+          <div>
+            <div className="text-blue-400 font-bold mb-1">UPCOMING</div>
+            <div className="space-y-1 text-gray-500">
+              {[1, 2, 3].map(offset => {
+                const lyric = lyricsData[currentLyricIndex + offset]
+                if (!lyric) return null
+                return (
+                  <div key={currentLyricIndex + offset} className="text-xs">
+                    [{currentLyricIndex + offset}] {formatTime(lyric.time)}: {lyric.text.substring(0, 40)}...
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/SyncOffsetIndicator.tsx
+++ b/src/components/SyncOffsetIndicator.tsx
@@ -1,25 +1,74 @@
 interface SyncOffsetIndicatorProps {
   offset: number
+  onAdjust: (delta: number) => void
+  onReset: () => void
 }
 
-export default function SyncOffsetIndicator({ offset }: SyncOffsetIndicatorProps) {
-  if (offset === 0) return null
-  
+export default function SyncOffsetIndicator({ offset, onAdjust, onReset }: SyncOffsetIndicatorProps) {
   const formatOffset = (value: number) => {
     const sign = value >= 0 ? '+' : ''
     return `${sign}${value.toFixed(1)}s`
   }
   
   return (
-    <div className="fixed top-4 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg z-50 animate-pulse">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium">Sync Offset:</span>
-        <span className={`text-lg font-bold ${offset > 0 ? 'text-green-400' : 'text-orange-400'}`}>
-          {formatOffset(offset)}
-        </span>
+    <div className="fixed bottom-24 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-4 py-3 rounded-lg shadow-lg z-40 border border-gray-700">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium text-gray-300">Sync Offset:</span>
+        
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onAdjust(-1.0)}
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs transition-colors"
+            title="Decrease by 1s"
+          >
+            -1s
+          </button>
+          <button
+            onClick={() => onAdjust(-0.1)}
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs transition-colors"
+            title="Decrease by 0.1s"
+          >
+            -0.1s
+          </button>
+          
+          <span className={`text-lg font-bold min-w-[60px] text-center ${
+            offset === 0 ? 'text-gray-400' : offset > 0 ? 'text-green-400' : 'text-orange-400'
+          }`}>
+            {formatOffset(offset)}
+          </span>
+          
+          <button
+            onClick={() => onAdjust(0.1)}
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs transition-colors"
+            title="Increase by 0.1s"
+          >
+            +0.1s
+          </button>
+          <button
+            onClick={() => onAdjust(1.0)}
+            className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs transition-colors"
+            title="Increase by 1s"
+          >
+            +1s
+          </button>
+          
+          {offset !== 0 && (
+            <button
+              onClick={onReset}
+              className="px-2 py-1 bg-red-900 hover:bg-red-800 rounded text-xs transition-colors ml-2"
+              title="Reset to 0"
+            >
+              Reset
+            </button>
+          )}
+        </div>
       </div>
-      <div className="text-xs text-gray-400 mt-1">
-        Press [ or ] to adjust • Shift for ±1s
+      
+      <div className="text-xs text-gray-400 mt-2 text-center">
+        Keyboard: [ / ] to adjust • Shift for ±1s • Shift+D for debug
+        <div className="mt-1">
+          <span className="text-green-400">+offset</span> = delay lyrics (for intros) • <span className="text-orange-400">-offset</span> = lyrics earlier
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Added comprehensive time offset functionality to synchronize lyrics with YouTube videos that have intros
- Implemented both visual controls and keyboard shortcuts for adjusting sync timing
- Created a debug panel for monitoring real-time sync data and troubleshooting

## Changes
### Core Functionality
- **Sync Offset Controls**: Added buttons for ±0.1s and ±1s adjustments with visual feedback
- **Keyboard Shortcuts**: [ and ] keys adjust offset, Shift modifier for larger increments
- **Offset Behavior**: Positive offset delays lyrics (for video intros), negative makes them appear earlier

### UI Improvements
- Created `SyncOffsetIndicator` component with interactive controls
- Added reset button for quick return to zero offset
- Color-coded offset display (green for positive, orange for negative)
- Clear labeling of offset effects

### Debug Features
- New `DebugPanel` component (toggle with Shift+D) showing:
  - Real-time video and adjusted timing
  - Lyric index tracking and expected vs actual comparison
  - Player state monitoring
  - Typing progress visualization
  - Timing differences between lyrics

### Bug Fixes
- Fixed JavaScript closure issues causing pause/resume problems
- Resolved state synchronization using refs for real-time accuracy
- Corrected offset direction to match user expectations
- Fixed logic that was preventing proper video pausing

## Test Plan
- [x] Test positive offset delays lyrics for video intros
- [x] Test negative offset makes lyrics appear earlier
- [x] Verify keyboard shortcuts work correctly
- [x] Confirm debug panel shows accurate timing data
- [x] Check that offset persists per video in localStorage
- [x] Verify pause/resume works correctly with offset changes
- [x] Test that typing completion resumes video playback

🤖 Generated with [Claude Code](https://claude.ai/code)